### PR TITLE
change the tempdb name function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,10 +14,8 @@ create_temp_database <- function(conn) {
 get_database_name_from_userid <- function(user_id) {
 
   end_str <- user_id %>%
-    stringr::str_split(":") %>%
-    unlist() %>% tail(1) %>%
-    stringr::str_split("-", n = 2) %>%
-    unlist() %>% tail(1)%>%
+    stringr::str_remove("^.*:") %>% # remove everything before the colon
+    stringr::str_remove("_[0-9]*[.][0-9]*$") %>% #remove the trailing decimal number
     stringr::str_replace_all("-", "_") %>%
     stringr::str_replace_all("\\.", "_")
 


### PR DESCRIPTION
HI @mratford - I've been checking over Rdbtools again since it's getting more attention and I found my temporary db name has gone funny.  I've updated the regex to remove the outer parts - I think possibly something changed with the new auth, compounded with the fact I have a dash in my github username which was splitting the string in the wrong place.

Can you have a quick check I'v not done anything crazy?

Thanks,
Peter