### PR TITLE
Added a new env variable for crossing-region scenario (app migration)

### DIFF
--- a/R/credentials.R
+++ b/R/credentials.R
@@ -11,7 +11,9 @@ is_auth_within_expiry <- function(con, window = 5 * 60) {
 # Check for region in environment variables, otherwise use 'eu-west-1'
 # as the default
 get_region <- function() {
-  if (nchar(Sys.getenv("AWS_DEFAULT_REGION")) > 0) {
+  if (nchar(Sys.getenv("AWS_ATHENA_QUERY_REGION")) > 0) {
+    return(Sys.getenv("AWS_ATHENA_QUERY_REGION"))
+  } else if (nchar(Sys.getenv("AWS_DEFAULT_REGION")) > 0) {
     return(Sys.getenv("AWS_DEFAULT_REGION"))
   } else if (nchar(Sys.getenv("AWS_REGION")) > 0) {
     return(Sys.getenv("AWS_REGION"))

--- a/R/credentials.R
+++ b/R/credentials.R
@@ -8,8 +8,15 @@ is_auth_within_expiry <- function(con, window = 5 * 60) {
   )
 }
 
-# Check for region in environment variables, otherwise use 'eu-west-1'
-# as the default
+# Check for region in environment variables based on the following order.
+# AWS_ATHENA_QUERY_REGION: 
+#   An environment variable for specifying the region when the region 
+#   where the query will be run is different from the default region 
+#   from underlying running environment.
+# AWS_DEFAULT_REGION and AWS_REGION:
+#   The default region. Usually the 2 variables will be setup by the
+#   underlying running environment e.g. cluster, and they cannot be amended
+# othewise use 'eu-west-1' as the default
 get_region <- function() {
   if (nchar(Sys.getenv("AWS_ATHENA_QUERY_REGION")) > 0) {
     return(Sys.getenv("AWS_ATHENA_QUERY_REGION"))

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ Note that if you need any function within dbplyr which does a copy (e.g. joining
 then you need to ensure you have the right permissions for the staging directory you are using.
 See the help page for `dbWriteTable` by running `?dbWriteTable` in the console.
 
+### The region argument when creating connection object
+
+The region passed into the connect_athena() will be used for 
+- Get temporary token for connecting athena service
+- Run the query and store the query result to the staging dir
+
+In order to run the query successfully, the region need to the region where the query will be run and query result will be stored in the staging dir. You can pass the value based on your case when calling connect_athena(), by default, the region will be decided based on serveral environment variables below:
+
+- `AWS_ATHENA_QUERY_REGION`: An environment variable for specifying the region when the region where the query will be run is different from the default region from underlying running environment.
+
+- `AWS_DEFAULT_REGION` and `AWS_REGION`: The default region which usually will be setup by the underlying running environment e.g. cluster, and they cannot be amended
+
+othewise use `eu-west-1` as the default
+
+In most cases, you do not need to worry about the region, the default region (`AWS_DEFAULT_REGION` and `AWS_REGION`) should be one for running query and the one where your staging dir is.  When there is cross-region situation in your runnning environment and you want to save the time for passing the region every time when creating connection, you can use the `AWS_ATHENA_QUERY_REGION` to specify it. 
+
 ### Single queries (deprecated)
 
 The function `read_sql` is provided which replicates the same function from `dbtools` - this is kept for backwards compatibility only.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ In order to run the query successfully, the region need to the region where the 
 
 othewise use `eu-west-1` as the default
 
-In most cases, you do not need to worry about the region, the default region (`AWS_DEFAULT_REGION` and `AWS_REGION`) should be one for running query and the one where your staging dir is.  When there is cross-region situation in your runnning environment and you want to save the time for passing the region every time when creating connection, you can use the `AWS_ATHENA_QUERY_REGION` to specify it. 
+In most cases, you do not need to worry about the region, the default region (`AWS_DEFAULT_REGION` and `AWS_REGION`) should be the one for running query and the one where your staging dir is.  When there is cross-region situation in your runnning environment and you want to save the time for passing the region every time when creating connection, you can use the `AWS_ATHENA_QUERY_REGION` to specify it. 
 
 ### Single queries (deprecated)
 


### PR DESCRIPTION
This PR is to address athena connection issue, for one of dashboard apps ( gold-scorecard-form (https://github.com/moj-analytical-services/gold-scorecard-form)

The platform we are going to use for all the AP dashboard apps is  Cloud-platform (central moj infrastructure),  their AWS resources are managed under different account and region they use is `eu-west-2`,  but our athena service and all the datasets (buckets) we manage are under admin-data account with region `eu-west-1`,  so there are involved some cross-accounts and cross-region issue. 

Last week we managed to get the cross-account permission work, then found out the region on `AWS_DEFAULT_REGION` and `AWS_REGION` are linked to the underline cluster, we cannot overwrite it

This PR is to introduce an new alternative env var for Rdbtools to retrieve the default region of s3 buckets ( `AWS_ATHENA_QUERY_REGION`), it will give benefit of requiring only minor changes to other apps using this R pacakge

@mratford  @pjrh-moj , what do you think?  keen to hear your feedback, as we want to get the app change done asap