### PR TITLE
Add temp default schema

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rdbtools
 Title: Connects the MoJ Analytical Platform to Athena
-Version: 0.3.0
+Version: 0.4.0
 Authors@R: 
     person(given = "First",
            family = "Last",

--- a/R/athena_connection.R
+++ b/R/athena_connection.R
@@ -22,14 +22,16 @@ setClass(
 #' methods from noctua's AthenaConnection class, which in turn are DBI
 #' methods.
 #' In general the expected usage is to run the function with no arguments to
-#' get a standard database connection, which should work for most purposes.
+#' get a standard database connection, which should work for most basic data
+#' access purposes.
 #'
 #' @param aws_region This is the region where the database is held. If unset or NULL then will default to the AP's region.
 #' @param staging_dir This the s3 location where outputs of queries can be held. If unset or NULL then will default to a session specific temporary dir.
 #' @param rstudio_conn_tab Set this to true to show this connection in you RStudio connections frame (warning: this takes a long time to load because of the number of databases in the AP's Athena)
 #' @param session_duration The number of seconds which the session should last before needing new authentication. Minimum of 900.
 #' @param role_session_name This is a parameter for authentication, and should be left to NULL in normal operation.
-#' @param schema_name This is the default database that tables not specifying a database will be looked in. If this is set to the string "__temp__" then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the __temp__ keyword, alongside the DBI commands.
+#' @param schema_name This is the default database that tables not specifying a database will be looked in. If this is set to the string `__temp__` then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the `__temp__` keyword, alongside the DBI commands.
+#' @param ... Other agruments passed to `dbConnect`
 #'
 #' @examples
 #'  con <- connect_athena() # creates a connection with sensible defaults

--- a/R/athena_connection.R
+++ b/R/athena_connection.R
@@ -29,6 +29,7 @@ setClass(
 #' @param rstudio_conn_tab Set this to true to show this connection in you RStudio connections frame (warning: this takes a long time to load because of the number of databases in the AP's Athena)
 #' @param session_duration The number of seconds which the session should last before needing new authentication. Minimum of 900.
 #' @param role_session_name This is a parameter for authentication, and should be left to NULL in normal operation.
+#' @param schema_name This is the default database that tables not specifying a database will be looked in. If this is set to the string "__temp__" then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the __temp__ keyword, alongside the DBI commands.
 #'
 #' @examples
 #'  con <- connect_athena() # creates a connection with sensible defaults
@@ -165,6 +166,7 @@ connect_athena <- function(aws_region = NULL,
   con@MoJdetails$temp_db_name <- temp_db_name
   con@MoJdetails$temp_db_exists <- NA # Don't know if the temp db exists yet
 
+  # this checks that the temp database exists if it is set as the default db
   if (schema_name == "__temp__") {
     result <- athena_temp_db(con, check_exists = TRUE)
   }

--- a/man/connect_athena.Rd
+++ b/man/connect_athena.Rd
@@ -25,7 +25,9 @@ connect_athena(
 
 \item{role_session_name}{This is a parameter for authentication, and should be left to NULL in normal operation.}
 
-\item{schema_name}{This is the default database that tables not specifying a database will be looked in. If this is set to the string "\strong{temp}" then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the \strong{temp} keyword, alongside the DBI commands.}
+\item{schema_name}{This is the default database that tables not specifying a database will be looked in. If this is set to the string \verb{__temp__} then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the \verb{__temp__} keyword, alongside the DBI commands.}
+
+\item{...}{Other agruments passed to \code{dbConnect}}
 }
 \description{
 Creates a connection object which permits the user to interact with the
@@ -35,7 +37,8 @@ This returns an object with class MoJAthenaConnection, which inherits
 methods from noctua's AthenaConnection class, which in turn are DBI
 methods.
 In general the expected usage is to run the function with no arguments to
-get a standard database connection, which should work for most purposes.
+get a standard database connection, which should work for most basic data
+access purposes.
 }
 \examples{
  con <- connect_athena() # creates a connection with sensible defaults

--- a/man/connect_athena.Rd
+++ b/man/connect_athena.Rd
@@ -10,6 +10,7 @@ connect_athena(
   rstudio_conn_tab = FALSE,
   session_duration = 3600,
   role_session_name = NULL,
+  schema_name = "default",
   ...
 )
 }
@@ -23,6 +24,8 @@ connect_athena(
 \item{session_duration}{The number of seconds which the session should last before needing new authentication. Minimum of 900.}
 
 \item{role_session_name}{This is a parameter for authentication, and should be left to NULL in normal operation.}
+
+\item{schema_name}{This is the default database that tables not specifying a database will be looked in. If this is set to the string "\strong{temp}" then it will use (and create if required) the temporary database based on your username - this is useful for using dbplyr which does not understand the \strong{temp} keyword, alongside the DBI commands.}
 }
 \description{
 Creates a connection object which permits the user to interact with the


### PR DESCRIPTION
This PR allows the user to set the default database of the Athena connection object to be their temporary database (and it is created if required).  This is useful for places where the temporary keyword doesn't work (anything not using DBI under the hood), because then the temp database is used if nothing else is specified.  This has made using `dbplyr` much easier for me, reducing the number of manual string substitutions I was doing.

There only file which has changed code is `R/athena_connection.R`, the rest is all documentation changes.

There is one additional argument to `connect_athena` which can now be run as so:
`con <- connect_athena(schema_name = "__temp__")`
which sets the default database to be the user's temp db, which is based on their AWS userid.