### PR TITLE
Get table metadata fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports:
     DBI,
-    noctua,
+    noctua (== 2.6.1),
     magrittr,
     vroom,
     paws,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rdbtools
 Title: Connects the MoJ Analytical Platform to Athena
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: 
     person(given = "First",
            family = "Last",

--- a/R/db_commands.R
+++ b/R/db_commands.R
@@ -125,10 +125,11 @@ setMethod("dbExistsTable", c("MoJAthenaConnection","character"),
               ),
               type = "message")
 
-            # abort if the above has returned an error
-            if (inherits(resp, "error")) rlang::abort("Error in dbExistsTable response.", parent = resp)
             # put the retries back
             noctua_options(retry = actual_retry_setting)
+                    
+            # abort if the above has returned an error
+            if (inherits(resp, "error")) rlang::abort("Error in dbExistsTable response.", parent = resp)
             return(resp)
           }
 )

--- a/R/db_commands.R
+++ b/R/db_commands.R
@@ -106,7 +106,18 @@ setMethod("dbExistsTable", c("MoJAthenaConnection","character"),
             # prepare the statement
             name <- prepare_name(conn, name)
             # run the query using the noctua function
-            getMethod("dbExistsTable", c("AthenaConnection","character"), asNamespace("noctua"))(conn, name, ...)
+            noctua_options(retry = 1)
+            cnd <- capture.output(
+            resp <- rlang::try_fetch(getMethod("dbExistsTable", c("AthenaConnection","character"), asNamespace("noctua"))(conn, name, ...),
+                             error = function(cnd) {
+                               #browser()
+                               if (grepl("EntityNotFoundException", cnd$message)) return(FALSE)
+                               else return(cnd)
+                             }
+            ),
+            type = "message")
+            noctua_options(retry = 5)
+            return(resp)
           }
 )
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The secondary purpose of this package is to provide backwards compatability with
 For this the package provides a few convenience functions for MoJ users.
 The key difference with this package over `dbtools` is that it is implemented all in R and doesn't require a Python dependency.
 
-## Installing Rdbtools
+### Installing Rdbtools
 
 Then install Rdbtools with one of the the following commands:
 
@@ -25,6 +25,14 @@ Then install Rdbtools with one of the the following commands:
  - If not using renv: `devtools::install_github("moj-analytical-services/Rdbtools")` (you may need to install devtools first)
 
 You can use the same command to update the package, if it is changed on Github later.
+
+### Limitations
+
+Currently we have pinned `Rdbtools` to noctua version 2.6.1 because later versions query tables' metadata to check for existence
+and for the S3 storage location - this requires the permission `athena:GetTableMetadata` which is currently not standard on the
+Analytical Platform.
+Currently this does not mean loss of any features, but it may mean that over time the package has to workaround this permission issue
+or else users will need to get the permission added to their account.
 
 ## How to use
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,3 @@
 library(testthat)
-library(Rdbtools)
 
 test_check("Rdbtools")

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -8,8 +8,8 @@ test_reconnection <- rstudioapi::showPrompt("Test reconnection",
 ath_con <- connect_athena(staging_dir = user_staging_dir,
                           session_duration = 900)
 
-df <- data.frame(a = c(1,2,3),
-                 b = c("a", "b", "c"))
+df <- data.frame(a = c("a", "b", "c"),
+                 b = round(runif(3)*100))
 
 
 


### PR DESCRIPTION
After investigating the issue where `dbWriteTable` broke because `dbExistsTable` had a new error message from Athena
(see here: https://asdslack.slack.com/archives/C8X3PP1TN/p1689335302066809)

Then the fix was applied to `noctua`: https://github.com/DyfanJones/noctua/issues/205
However, `noctua` has made an unrelated change which means that some basic things like checking the existence of tables now relies on an API call which requires the `athena:GetTableMetadata` which standard AP users do not have.

This PR patches the `Rbtools` version of `dbExistsTable` so that it catches the new error (it's a bit hacky, but it works fine) and pins the version of `noctua` to 2.6.1 so that no one ends up with the version which they don't have the right permissions for.

This is probably a short-term fix, as we will now not benefit from future package development.  I'm not sure whether this new permission is problematic to be granted, or whether there is another workaround we can implement in `Rbtools`...