### PR TITLE
Ensure role_session_name persists when refreshing credentials

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Rdbtools
 Title: Connects the MoJ Analytical Platform to Athena
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: 
     person(given = "First",
            family = "Last",

--- a/R/athena_connection.R
+++ b/R/athena_connection.R
@@ -62,7 +62,9 @@ connect_athena <- function(aws_region = NULL,
 
     authentication_expiry <- as.POSIXct(credentials$Credentials$Expiration, origin = "1970-01-01", tz="UTC")
 
+    # Get the roles assumed
     user_id <- credentials$AssumedRoleUser$AssumedRoleId
+    role_session_name <- strsplit(user_id, ":")[[1]][[2]]
 
     # work out what your staging dir should be on the AP if unset
     if (is.null(staging_dir)) {


### PR DESCRIPTION
### Issue:

When `Rdbtools` was updated to use the `paws`  functions to get credentials then the role_session_name was not being set to the slot of the connection object and so was not being used when the connection object was being refreshed.